### PR TITLE
removing templateUrl in favor of html-string template

### DIFF
--- a/poster.html
+++ b/poster.html
@@ -1,1 +1,0 @@
-<img ng-src="{{vgUrl}}" ng-class="vgStretch">

--- a/poster.js
+++ b/poster.js
@@ -10,7 +10,7 @@ angular.module("com.2fdevs.videogular.plugins.poster", [])
 					vgUrl: "=",
 					vgStretch: "="
 				},
-				templateUrl: "views/videogular/plugins/poster/poster.html",
+				template: '<img ng-src="{{vgUrl}}" ng-class="vgStretch">',
 				link: function(scope, elem, attr, API) {
 					var img = elem.find("img");
 					var width = 0;


### PR DESCRIPTION
Removed `templateUrl` as discussed -- was wondering if you wanted this change in the bower repository or the main videogular repo? If this is the right place I'll go ahead and duplicate this effort for the remaining plugins...
