### PR TITLE
Fix main to 'vg-poster.js' in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videogular-poster",
   "version": "1.0.0",
-  "main": "./poster.js",
+  "main": "./vg-poster.js",
   "dependencies": {
     "videogular": "latest"
   }


### PR DESCRIPTION
The Wiredep can not add files , because of the wrong file name in the mian bower.json